### PR TITLE
Update script to extract the energy data localling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,163 @@
-## ⚠️ UPDATE – February 24, 2026
-EMAIL RESPONSE FROM CURB:
-
-Dear Curb Customer,
- 
-We regret to inform you that Curb's cloud support has been discontinued. Any active subscriptions have been cancelled with the remainder of the current period refunded.
- 
-There are no plans at this time to restore support for your device.
-
-CURB team,
-
-## ⚠️ UPDATE – February 23, 2026
-
-Curb's API currently appears to be unavailable.  
-The support email (support@energycurb.com) is also unreachable.
-
-It is possible that the service has been discontinued or temporarily shut down.  
-At this time, all integrations depending on the API are not functioning.
-
-If you have any additional information or updates, please share them via Issues.
 
 # **Curb-to-Mqtt**
-![Github-Mqtt](https://github.com/luisgarcia87/Curb-to-Mqtt/blob/main/Curb-to-Mqtt-small.png)
-
-⚠️ New Update (v1.0.1): Debug mode added, reduced output, improved stability. See the [latest release](https://github.com/luisgarcia87/Curb-to-Mqtt/releases) for details.
 
 ## Overview
 Curb Energy is a company that provides real-time energy monitoring solutions. Their flagship product, the Curb energy monitor, is a hardware device that connects to an electrical panel to track electricity usage at the circuit level.
 
-The Curb-to-Mqtt project enables real-time monitoring of energy consumption through Curb's API, integrating this data with MQTT for efficient communication with smart home systems. This solution pulls live data from Curb's WebSocket, transforms it, and publishes it to an MQTT broker, allowing users to receive energy consumption information from their circuits in real time.
+As of February 24, 2026, Curb has discontinued their cloud support, rendering the existing devices nearly useless.
+However the devices do expose log files locally, which can be accessed to extract the power usage data.
 
-## Features
-- **OAuth 2.0 Authentication**: The script automatically authenticates with the Curb API to obtain a user-specific access token.
-- **Location Fetching**: Fetches the user's location ID dynamically using the authentication token, ensuring that the data corresponds to the correct location.
-- **MQTT Integration**: Publishes energy consumption data to a configurable MQTT broker. Supports both authenticated and non-authenticated MQTT brokers.
-- **Dynamic Configuration**: Configuration values such as API credentials, MQTT settings, and more can be stored in a configurable YAML file with support for comments.
-- **Debug Mode**: A new debug mode has been added to reduce excessive logging, helping to improve the stability of the service. You can enable more detailed logs by setting `DEBUG_MODE: true` in the `config.yaml`.
+The Curb-to-Mqtt project enables monitoring of energy consumption, integrating this data with MQTT for efficient communication with smart home systems. This solution polls a local [Curb Energy Monitor](https://energycurb.com/) status page, parses the load controller log, and publishes per-circuit power readings to an MQTT broker using [Home Assistant MQTT discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery).
 
+---
 
-## Requirements
-- Node.js (version 16 or later recommended)
-- MQTT Broker (can be local or cloud-based)
-- Curb Account (with valid API credentials)
+## How it works
+
+The Curb device exposes a status page at `http://<device-ip>/`. This script:
+
+1. Fetches the page every 5 minutes (1 minute if no new data was found).
+2. Extracts all `Load control got aggregated sample` lines from the load controller log.
+3. Parses the JSON payload in each line, converting the 18 per-circuit Wh/minute readings to watts (`Wh × 60 = W`).
+4. Publishes any samples with a timestamp newer than the last published one, in chronological order.
+5. On first connect, publishes Home Assistant MQTT discovery messages so the device and all 18 sensors appear automatically.
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) v16 or newer
+- An MQTT broker (e.g. [Mosquitto](https://mosquitto.org/)) accessible on your network
+- Your Curb device reachable by IP on the local network
+
+---
 
 ## Installation
 
-**Clone the repository:**
-```
-git clone https://github.com/luisgarcia87/Curb-to-Mqtt.git
-cd Curb-to-Mqtt
-```
-
-**Install dependencies:**
-Run this command inside the folder where the script is located.
-```
+```bash
+git clone https://github.com/pvanbaren/Curb-to-Mqtt.git
+cd curb-to-mqtt
 npm install
 ```
-If you encounter errors you might need to run the command as:
-```
-sudo npm install
-```
-**Edit the configuration file:** Edit the config.yaml file in the root directory of the project, and specify your Curb API credentials and MQTT settings.
 
-Example **config.yaml**:
+### Dependencies
 
-```
-TOKEN_URL: "https://energycurb.auth0.com/oauth/token"
-CLIENT_ID: "iKAoRkr3qyFSnJSr3bodZRZZ6Hm3GqC3" # Official client_id from Curb #
-CLIENT_SECRET: "dSoqbfwujF72a1DhwmjnqP4VAiBTqFt3WLLUtnpGDmCf6_CMQms3WEy8DxCQR3KY" # Official client_secret from Curb #
-USERNAME: "YOUR-CURB-USERNAME" # Curb's login username/email information #
-PASSWORD: "YOUR-CURB-PASSWORD" # Curb's password information #
-AUDIENCE: "app.energycurb.com/api" 
-MQTT_BROKER_URL: "mqtt://YOUR-MQTT-BROKER:1883" # MQTT Broker URL, default port 1883 #
-MQTT_TOPIC: "home/curb/power" # You can change the topic to what ever you like it to be #
-MQTT_USERNAME: "YOUR-MQTT-USERNAME"  # Leave empty if no username is needed
-MQTT_PASSWORD: "YOUR-MQTT-PASSWORD"  # Leave empty if no password is needed
-DEBUG_MODE: false # Set to true to enable detailed logging for debugging purposes.
-```
-Change **USERNAME, PASSWORD, MQTT_BROKER_URL, MQTT_USERNAME, MQTT_PASSWORD** with your own information, you may leave **MQTT_TOPIC** as is or change it to your topic of preference.
+| Package | Purpose |
+|---|---|
+| `axios` | HTTP polling |
+| `mqtt` | MQTT client |
+| `js-yaml` | Config file parsing |
 
-Run the following command in the folder where the script is located:
+Install them if not already present:
+
+```bash
+npm install axios mqtt js-yaml
 ```
+
+---
+
+## Configuration
+
+Copy or create `config.yaml` in the same directory as `curb-to-mqtt.js`:
+
+```yaml
+# URL of the Curb device status page
+POLL_URL: "http://192.168.1.236/"
+
+# MQTT broker connection
+MQTT_BROKER_URL: "mqtt://192.168.1.10"
+MQTT_USERNAME: ""
+MQTT_PASSWORD: ""
+
+# Base MQTT topic — each circuit publishes to MQTT_TOPIC/circuit_N
+MQTT_TOPIC: "curb/power"
+
+# Home Assistant MQTT discovery prefix (must match HA configuration)
+HA_DISCOVERY_PREFIX: "homeassistant"
+
+# Unique identifier for this device (no spaces; the serial number works well)
+DEVICE_ID: "curb_cmwg37ps"
+
+# Friendly name shown in Home Assistant
+DEVICE_NAME: "Curb Energy Monitor"
+
+# Optional: friendly names for each of the 18 circuits, in order.
+# Any omitted entries default to "Circuit N".
+CIRCUIT_NAMES:
+  - "Main L1"
+  - "Kitchen"
+  - "Refrigerator"
+  - "Dryer"
+  - "Washer"
+  - "HVAC"
+  - "Main L2"
+  - "Water Heater"
+  - "Dishwasher"
+  - "Microwave"
+  - "Garage"
+  - "Office"
+  - "Master Bedroom"
+  - "Living Room"
+  - "Outdoor Lights"
+  - "Circuit 16"
+  - "Circuit 17"
+  - "Circuit 18"
+
+# Set to true to enable verbose logging
+DEBUG: false
+```
+
+### Finding your circuit order
+
+Enable `DEBUG: true` on the first run. The script logs each circuit value in order (`circuit_1` through `circuit_18`). Cross-reference these with known loads (e.g. turn a large appliance on/off) to identify each circuit and fill in `CIRCUIT_NAMES`.
+
+---
+
+## Running manually
+
+```bash
 node curb-to-mqtt.js
 ```
-This will initiate the connection, authenticate, fetch your location ID, and start subscribing to the Curb WebSocket for real-time data and forward it via MQTT.
 
+With debug output:
 
-## How It Works
-1. Authentication with Curb API
-The script first fetches an authentication token from the Curb API using your CLIENT_ID, CLIENT_SECRET, USERNAME, and PASSWORD. This token is used to authenticate further API requests.
+```bash
+DEBUG=true node curb-to-mqtt.js
+```
 
-2. Fetching Location ID
-Once authenticated, the script makes a GET request to Curb's /locations endpoint, passing the token in the request header. The location ID of your account's first location is retrieved and used to subscribe to your circuits' data.
+Or set `DEBUG: true` in `config.yaml`.
 
-3. Connecting to WebSocket
-With the token and location ID in hand, the script connects to Curb's WebSocket API (/api/circuit-data). It subscribes to real-time data for the specified location and waits for updates on circuit consumption.
+---
 
-4. MQTT Integration
-The data received from the Curb WebSocket (such as circuit power consumption) is then formatted and published to the configured MQTT broker under the topic home/curb/power/{circuit-id}.
+## Home Assistant integration
 
-5. Token Refresh
-To ensure continuous operation, the script automatically refreshes the authentication token every 12 hours to avoid expiration, and re-authenticates with the WebSocket if necessary.
+The script uses MQTT discovery, so no manual sensor configuration is required. Ensure the [MQTT integration](https://www.home-assistant.io/integrations/mqtt/) is enabled in Home Assistant with the same broker.
 
-## Debug Mode (v1.0.1 Update)
-In version 1.0.1, debug mode has been introduced to address issues caused by excessive logging output. You can enable detailed logging by setting `DEBUG_MODE: true` in the `config.yaml` file. This will allow you to see more detailed logs for troubleshooting purposes, but by default, the script runs with reduced logging to improve stability and performance.
+On first run, a device named **Curb Energy Monitor** (or your `DEVICE_NAME`) will appear under **Settings → Devices & Services → MQTT** with 18 power sensors. Each sensor has:
+
+- **Unit:** W
+- **Device class:** Power
+- **State class:** Measurement (compatible with the Energy dashboard)
+
+---
+
+## Polling behaviour
+
+| Condition | Next poll delay |
+|---|---|
+| New samples published | 5 minutes |
+| No new data found | 1 minute |
+
+The Curb status page updates approximately every 5–6 minutes and retains ~60–90 minutes of per-minute samples. On each successful poll the script publishes all samples newer than the last known timestamp, so no readings are skipped if a poll is delayed.
+
+---
+
+## MQTT topic structure
+
+| Topic | Payload |
+|---|---|
+| `curb/power/circuit_N` | `{"circuit": N, "power": 1234.5, "t": 1772837437}` |
+
+All messages are published with `retain: true`.
 
 ## Running as a service ##
 
@@ -179,78 +234,13 @@ tail -f /var/log/curb.log
 
 ## Adding MQTT Sensor to Home Assistant
 
-To monitor the power consumption of your Curb circuits in Home Assistant, you need to create MQTT sensors that subscribe to the topics published by the `Curb-to-Mqtt` script. The script will publish data to MQTT topics in the following format:
-
-> home/curb/power/{circuid-id}
-
-Each topic corresponds to a specific circuit and contains the power consumption data (in watts) and other attributes in the message payload.
-
-### Example Configuration for Home Assistant
-
-Below is an example configuration for an MQTT sensor in Home Assistant to monitor the power consumption of a circuit:
-```
-mqtt:
-  sensor:
-    - name: "Kitchen Dishwasher Power"
-      state_topic: "home/curb/power/{circuit-id}"
-      value_template: "{{ value_json.power }}"
-      unit_of_measurement: "W"
-      device_class: power
-      json_attributes_topic: "home/curb/power/{circuit-id}"
-      json_attributes_template: "{{ value_json | tojson }}"
-```
-## Explanation of Configuration
-- name: The name of the sensor as it will appear in Home Assistant. In this case, it is "Kitchen Dishwasher Power".
-- state_topic: The MQTT topic to subscribe to for receiving power consumption data. - The {circuit-id} in the topic corresponds to the unique ID of the circuit.
-- value_template: A Jinja template to extract the power value from the received JSON payload. This value represents the power consumption of the circuit in watts.
-- unit_of_measurement: The unit for the sensor value. In this case, it's "W" for watts.
-- device_class: Defines the type of sensor. Setting this to power ensures the correct display of power-related data in Home Assistant.
-- json_attributes_topic: The topic that contains additional attributes for the sensor, such as the circuit ID, label, and other relevant data.
-- json_attributes_template: A Jinja template that converts the entire JSON payload into attributes in Home Assistant. The tojson filter converts the payload into a JSON string.
-
-## Multiple MQTT Sensors ###
-If you have multiple circuits, you can create additional sensors by replicating the configuration with different state_topic values for each unique circuit ID. For example:
-```
-mqtt:
-  sensor:
-    - name: "Kitchen Dishwasher Power"
-      state_topic: "home/curb/power/{circuit-id-1}"
-      value_template: "{{ value_json.power }}"
-      unit_of_measurement: "W"
-      device_class: power
-      json_attributes_topic: "home/curb/power/{circuit-id-1}"
-      json_attributes_template: "{{ value_json | tojson }}"
-
-    - name: "Water Pump & Deck Power"
-      state_topic: "home/curb/power/{circuit-id-2}"
-      value_template: "{{ value_json.power }}"
-      unit_of_measurement: "W"
-      device_class: power
-      json_attributes_topic: "home/curb/power/{circuit-id-2}"
-      json_attributes_template: "{{ value_json | tojson }}"
-```
-
-## Usage
-### Once the script is running, it will:
-
-- Continuously fetch real-time power consumption data from your Curb devices.
-- Publish this data to the configured MQTT broker under the topics specified in the MQTT_TOPIC.
-- Automatically refresh the authentication token every 12 hours.
-- You can monitor your energy consumption on any MQTT-compatible platform, such as Home Assistant, Node-RED, or other smart home applications.
-
-## Error Handling
-### The script includes error handling for:
-
-- Failed authentication with the Curb API.
-- Issues fetching location data.
-- Connection issues with the MQTT broker.
-- WebSocket disconnections, which are automatically reconnected after a brief delay.
-
-I am in no way an expert in this subject so feel free to comment and propose a better or improved code. I also need help if possible to make a custom HACS component out of this to be able to configure everything from Home Assistant UI.
+Install and configure the "Mosquitto broker" app in Home Assistant.
+The Curb energy monitor will then appear as a device, and the sensors as entities.
 
 ## Disclaimer
 This project is not affiliated with or endorsed by Curb Energy.
 
-If you found this helpful and want to show your appreciation, you can treat me to a coffee or a beer! I’ve put a lot of time into this working script, and it always makes my day when people say thanks.
+If you found this helpful and want to show your appreciation, you can treat Daniel Garcia to a coffee or a beer! He has put a lot of time into the original script, and it will put a smile
+on his face if someone says thanks.
 
 <a href="https://www.buymeacoffee.com/luisgarciak" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>

--- a/curb-to-mqtt.js
+++ b/curb-to-mqtt.js
@@ -97,7 +97,7 @@ function publishDiscovery(mqttClient) {
         const payload = {
             name: circuitName(i),
             unique_id: objId,
-            object_id: objId,
+            default_entity_id: `sensor.${objId}`,
             state_topic: stateTopic(i),
             value_template: '{{ value_json.power | round(1) }}',
             unit_of_measurement: 'W',

--- a/curb-to-mqtt.js
+++ b/curb-to-mqtt.js
@@ -1,142 +1,198 @@
 const axios = require('axios');
 const fs = require('fs');
-const io = require('socket.io-client');
 const mqtt = require('mqtt');
 const yaml = require('js-yaml');
 
-// Load configuration from config.yaml file
 const config = yaml.load(fs.readFileSync('config.yaml', 'utf8'));
 
-// Extracting values from the config object
-const { 
-    TOKEN_URL, CLIENT_ID, CLIENT_SECRET, USERNAME, PASSWORD, AUDIENCE, 
-    MQTT_BROKER_URL, MQTT_TOPIC, MQTT_USERNAME, MQTT_PASSWORD, DEBUG 
+const {
+    POLL_URL,           // "http://192.168.1.236/"
+    POLL_INTERVAL_MS,   // e.g. 10000
+    MQTT_BROKER_URL,
+    MQTT_TOPIC,         // e.g. "curb/power"
+    MQTT_USERNAME,
+    MQTT_PASSWORD,
+    DEVICE_ID,          // e.g. "curb_cmwg37ps"
+    DEVICE_NAME,        // e.g. "Curb Energy Monitor"
+    CIRCUIT_NAMES,      // optional array of 18 names, e.g. ["Main 1", "Kitchen", ...]
+    HA_DISCOVERY_PREFIX,// e.g. "homeassistant"
+    DEBUG
 } = config;
 
-// Debug logging function
+const DEVICE_ID_SAFE = (DEVICE_ID || 'curb').replace(/[^a-z0-9_]/gi, '_');
+
 function debugLog(...args) {
-    if (DEBUG) {
-        console.log('[DEBUG]', ...args);
-    }
+    if (DEBUG) console.log('[DEBUG]', ...args);
 }
 
-// Function to fetch a new access token
-async function fetchUserAccessToken() {
-    try {
-        const response = await axios.post(TOKEN_URL, {
-            grant_type: 'password',
-            audience: AUDIENCE,
-            username: USERNAME,
-            password: PASSWORD,
-            client_id: CLIENT_ID,
-            client_secret: CLIENT_SECRET
-        }, {
-            headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' }
-        });
-
-        debugLog('Access token fetched successfully.');
-        return response.data.access_token;
-    } catch (error) {
-        console.error('Error fetching access token:', error.message);
-        throw error;
-    }
+// ---------------------------------------------------------------------------
+// HTML parsing — split the entire page on <br> tags and keep only lines
+// that contain the aggregated sample marker.
+// ---------------------------------------------------------------------------
+function extractLogLines(html) {
+    return html
+        .split(/<br\s*\/?>/i)
+        .map(l => l.replace(/&nbsp;/g, ' ').replace(/<[^>]*>/g, '').trim())
+        .filter(l => l.includes('Load control got aggregated sample'));
 }
 
-// Function to fetch the location ID
-async function fetchLocationId(accessToken) {
-    try {
-        const response = await axios.get('https://app.energycurb.com/api/v3/locations', {
-            headers: { 'Authorization': `Bearer ${accessToken}` }
-        });
+const SAMPLE_RE = /INFO Load control got aggregated sample\s+(\{.+\})\s*$/;
 
-        if (response.data && response.data.length > 0) {
-            debugLog('Location ID fetched:', response.data[0].id);
-            return response.data[0].id;
-        } else {
-            console.error('No locations found.');
-            throw new Error('No locations found');
+function parseSampleLine(line) {
+    const m = line.match(SAMPLE_RE);
+    if (!m) return null;
+
+    let obj;
+    try { obj = JSON.parse(m[1]); } catch { return null; }
+
+    const watts = [];
+    for (const group of (obj.g || [])) {
+        for (const circuit of (group.c || [])) {
+            watts.push(circuit.w ?? 0);
         }
-    } catch (error) {
-        console.error('Error fetching location ID:', error.message);
-        throw error;
+    }
+
+    if (watts.length !== 18) {
+        debugLog(`Unexpected circuit count: ${watts.length}`);
+        return null;
+    }
+
+    // Wh over 1-minute interval → watts
+    for (let i = 0; i < watts.length; i++) {
+        watts[i] = Math.abs(watts[i]) * 60;
+    }
+
+    return { t: obj.t, watts };
+}
+
+// ---------------------------------------------------------------------------
+// Home Assistant MQTT discovery
+// ---------------------------------------------------------------------------
+function circuitName(idx) {
+    return (CIRCUIT_NAMES && CIRCUIT_NAMES[idx]) || `Circuit ${idx + 1}`;
+}
+
+function circuitObjectId(idx) {
+    return `${DEVICE_ID_SAFE}_circuit_${idx + 1}`;
+}
+
+function stateTopic(idx) {
+    return `${MQTT_TOPIC}/circuit_${idx + 1}`;
+}
+
+function publishDiscovery(mqttClient) {
+    const prefix = HA_DISCOVERY_PREFIX || 'homeassistant';
+
+    const device = {
+        identifiers: [DEVICE_ID_SAFE],
+        name: DEVICE_NAME || 'Curb Energy Monitor',
+        model: 'Curb',
+        manufacturer: 'Curb'
+    };
+
+    for (let i = 0; i < 18; i++) {
+        const objId = circuitObjectId(i);
+        const discoveryTopic = `${prefix}/sensor/${DEVICE_ID_SAFE}/${objId}/config`;
+
+        const payload = {
+            name: circuitName(i),
+            unique_id: objId,
+            object_id: objId,
+            state_topic: stateTopic(i),
+            value_template: '{{ value_json.power | round(1) }}',
+            unit_of_measurement: 'W',
+            device_class: 'power',
+            state_class: 'measurement',
+            device
+        };
+
+        mqttClient.publish(discoveryTopic, JSON.stringify(payload), { retain: true });
+        debugLog(`Discovery published: ${discoveryTopic}`);
     }
 }
 
-// Function to connect to Curb WebSocket and MQTT
-async function connectToLiveData() {
+// ---------------------------------------------------------------------------
+// Poll + publish
+// ---------------------------------------------------------------------------
+async function pollAndPublish(mqttClient, lastTimestampRef) {
+    let html;
     try {
-        let USER_ACCESS_TOKEN = await fetchUserAccessToken();
-        let LOCATION_ID = await fetchLocationId(USER_ACCESS_TOKEN);
-
-        debugLog('Connecting to WebSocket with location ID:', LOCATION_ID);
-
-        const socket = io('https://app.energycurb.com/api/circuit-data', {
-            transports: ['websocket'],
-            query: { token: USER_ACCESS_TOKEN }
-        });
-
-        const mqttOptions = {};
-        if (MQTT_USERNAME) mqttOptions.username = MQTT_USERNAME;
-        if (MQTT_PASSWORD) mqttOptions.password = MQTT_PASSWORD;
-
-        const mqttClient = mqtt.connect(MQTT_BROKER_URL, mqttOptions);
-
-        mqttClient.on('connect', () => debugLog('Connected to MQTT broker.'));
-        mqttClient.on('error', (err) => console.error('MQTT Error:', err));
-
-        socket.on('connect', () => {
-            debugLog('Connected to Curb WebSocket.');
-            socket.emit('authenticate', { token: USER_ACCESS_TOKEN });
-        });
-
-        socket.on('authorized', () => {
-            debugLog('WebSocket authentication successful.');
-            socket.emit('subscribe', LOCATION_ID);
-        });
-
-        socket.on('unauthorized', (err) => console.error('Authentication failed:', err));
-
-        socket.on('disconnect', () => {
-            debugLog('Disconnected from Curb WebSocket. Reconnecting in 5 seconds...');
-            setTimeout(connectToLiveData, 5000);
-        });
-
-        socket.on('error', (error) => console.error('Socket error:', error));
-
-        socket.on('data', (data) => {
-            debugLog('Received data from WebSocket.');
-            data.circuits.forEach(circuit => {
-                const payload = {
-                    id: circuit.id,
-                    label: circuit.label,
-                    power: circuit.w,
-                    type: circuit.circuit_type
-                };
-                const topic = `${MQTT_TOPIC}/${circuit.id}`;
-                mqttClient.publish(topic, JSON.stringify(payload));
-                debugLog('Published to MQTT:', topic, payload);
-            });
-        });
-
-        // Periodically refresh token every 12 hours
-        setInterval(async () => {
-            try {
-                const newToken = await fetchUserAccessToken();
-                if (newToken !== USER_ACCESS_TOKEN) {
-                    USER_ACCESS_TOKEN = newToken;
-                    socket.emit('authenticate', { token: USER_ACCESS_TOKEN });
-                    debugLog('Access token refreshed and re-authenticated.');
-                }
-            } catch (error) {
-                console.error('Error refreshing token:', error.message);
-            }
-        }, 43200000); // 12 hours
-    } catch (error) {
-        console.error('Error during setup:', error.message);
+        const res = await axios.get(POLL_URL, { timeout: 15000 });
+        html = res.data;
+    } catch (err) {
+        console.error('HTTP poll error:', err.message);
+        return;
     }
+
+    const lines = extractLogLines(html);
+    if (!lines.length) {
+        debugLog('Could not find Load controller log section.');
+        return;
+    }
+
+    // Collect all valid samples, sort oldest-first, publish any newer than last seen.
+    const samples = [];
+    for (const line of lines) {
+        const sample = parseSampleLine(line);
+        if (sample) samples.push(sample);
+    }
+
+    if (!samples.length) {
+        debugLog('No valid aggregated sample lines found.');
+        return;
+    }
+
+    samples.sort((a, b) => a.t - b.t);
+
+    const newSamples = samples.filter(s => lastTimestampRef.value === null || s.t > lastTimestampRef.value);
+    if (!newSamples.length) {
+        debugLog(`All ${samples.length} samples already published, skipping.`);
+        return;
+    }
+
+    debugLog(`Publishing ${newSamples.length} new sample(s) out of ${samples.length} total.`);
+
+    for (const sample of newSamples) {
+        debugLog(`  t=${sample.t} (${new Date(sample.t * 1000).toISOString()})`);
+        sample.watts.forEach((w, idx) => {
+            const topic = stateTopic(idx);
+            const payload = JSON.stringify({ circuit: idx + 1, power: w, t: sample.t });
+            mqttClient.publish(topic, payload, { retain: true });
+        });
+        lastTimestampRef.value = sample.t;
+    }
+
+    debugLog(`Last published t=${lastTimestampRef.value}`);
 }
 
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+async function main() {
+    const mqttOptions = {};
+    if (MQTT_USERNAME) mqttOptions.username = MQTT_USERNAME;
+    if (MQTT_PASSWORD) mqttOptions.password = MQTT_PASSWORD;
 
-// Start the connection process
-connectToLiveData();
+    const mqttClient = mqtt.connect(MQTT_BROKER_URL, mqttOptions);
+    mqttClient.on('connect', () => debugLog('Connected to MQTT broker.'));
+    mqttClient.on('error', err => console.error('MQTT error:', err));
 
+    const lastTimestampRef = { value: null };
+
+    async function scheduleNextPoll() {
+        const prevT = lastTimestampRef.value;
+        await pollAndPublish(mqttClient, lastTimestampRef);
+        const gotNewData = lastTimestampRef.value !== prevT;
+        const delay = gotNewData ? 5 * 60000 : 60000;
+        debugLog(`Next poll in ${delay / 1000}s (${gotNewData ? 'new data received' : 'no new data'})`);
+        setTimeout(scheduleNextPoll, delay);
+    }
+
+    mqttClient.once('connect', () => {
+        publishDiscovery(mqttClient);
+        debugLog(`Polling ${POLL_URL} (58s after new data, 15s if none)`);
+        scheduleNextPoll();
+    });
+}
+
+main();

--- a/curb-to-mqtt.py
+++ b/curb-to-mqtt.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Samples sink + MQTT bridge for EnergyCurb hubs.
+
+Accepts POST /v3/samples/<device> on plain HTTP, decodes the
+deflate + MessagePack body, appends a JSON line to samples.jsonl,
+and republishes the 18 per-circuit wattages to an MQTT broker
+(with Home Assistant discovery) — same topic layout as
+curb-to-mqtt.js.
+
+Usage:
+    pip install msgpack paho-mqtt pyyaml
+    python samples-to-mqtt.py [--config config.yaml] [--host 0.0.0.0] [--port 80]
+
+config.yaml keys (compatible with Curb-to-Mqtt/config.yaml):
+    MQTT_BROKER_URL      e.g. "mqtt://host:1883"
+    MQTT_TOPIC           base topic, e.g. "home/curb/power"
+    MQTT_USERNAME        optional
+    MQTT_PASSWORD        optional
+    HA_DISCOVERY_PREFIX  default "homeassistant"
+    DEVICE_ID            e.g. "curb_cmwg37ps"
+    DEVICE_NAME          e.g. "Curb Energy Monitor"
+    CIRCUIT_NAMES        list of up to 18 names
+    DEBUG                bool
+"""
+
+import argparse
+import datetime
+import json
+import re
+import sys
+import zlib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+import msgpack
+import paho.mqtt.client as mqtt
+import yaml
+
+SAMPLES_FILE    = "samples.jsonl"
+SAMPLES_PATH_RE = re.compile(r"^/v3/samples/([^/?#]+)")
+NUM_CIRCUITS    = 18
+WH_PER_SEC_TO_W = 3600   # interval is 1 s, so Wh * 3600 = W
+
+
+# ── config ────────────────────────────────────────────────────────────────────
+
+class Config:
+    def __init__(self, path: str):
+        with open(path) as f:
+            c = yaml.safe_load(f) or {}
+        self.broker_url        = c.get("MQTT_BROKER_URL", "mqtt://localhost:1883")
+        self.topic             = c.get("MQTT_TOPIC", "curb/power")
+        self.username          = c.get("MQTT_USERNAME") or None
+        self.password          = c.get("MQTT_PASSWORD") or None
+        self.ha_prefix         = c.get("HA_DISCOVERY_PREFIX", "homeassistant")
+        self.device_id         = c.get("DEVICE_ID", "curb")
+        self.device_name       = c.get("DEVICE_NAME", "Curb Energy Monitor")
+        self.circuit_names     = c.get("CIRCUIT_NAMES") or []
+        self.debug             = bool(c.get("DEBUG", False))
+        self.device_id_safe    = re.sub(r"[^a-z0-9_]", "_", self.device_id, flags=re.IGNORECASE)
+
+    def circuit_name(self, idx: int) -> str:
+        if idx < len(self.circuit_names) and self.circuit_names[idx]:
+            return self.circuit_names[idx]
+        return f"Circuit {idx + 1}"
+
+    def circuit_object_id(self, idx: int) -> str:
+        return f"{self.device_id_safe}_circuit_{idx + 1}"
+
+    def state_topic(self, idx: int) -> str:
+        return f"{self.topic}/circuit_{idx + 1}"
+
+
+def debug(cfg: Config, *args):
+    if cfg.debug:
+        print("[DEBUG]", *args)
+
+
+# ── MQTT ──────────────────────────────────────────────────────────────────────
+
+def connect_mqtt(cfg: Config) -> mqtt.Client:
+    u = urlparse(cfg.broker_url)
+    host = u.hostname or "localhost"
+    port = u.port or 1883
+
+    client = mqtt.Client()
+    if cfg.username:
+        client.username_pw_set(cfg.username, cfg.password or "")
+
+    def on_connect(c, _u, _f, rc):
+        if rc == 0:
+            print(f"[mqtt] connected to {host}:{port}")
+            publish_discovery(c, cfg)
+        else:
+            print(f"[mqtt] connect failed rc={rc}")
+
+    def on_disconnect(_c, _u, rc):
+        print(f"[mqtt] disconnected rc={rc}")
+
+    client.on_connect    = on_connect
+    client.on_disconnect = on_disconnect
+
+    print(f"[mqtt] connecting to {host}:{port} …")
+    client.connect_async(host, port, keepalive=60)
+    client.loop_start()
+    return client
+
+
+def publish_discovery(client: mqtt.Client, cfg: Config):
+    device = {
+        "identifiers":  [cfg.device_id_safe],
+        "name":         cfg.device_name,
+        "model":        "Curb",
+        "manufacturer": "Curb",
+    }
+    for i in range(NUM_CIRCUITS):
+        obj_id = cfg.circuit_object_id(i)
+        topic  = f"{cfg.ha_prefix}/sensor/{cfg.device_id_safe}/{obj_id}/config"
+        payload = {
+            "name":                 cfg.circuit_name(i),
+            "unique_id":            obj_id,
+            "default_entity_id":    f"sensor.{obj_id}",
+            "state_topic":          cfg.state_topic(i),
+            "value_template":       "{{ value_json.power | round(1) }}",
+            "unit_of_measurement":  "W",
+            "device_class":         "power",
+            "state_class":          "measurement",
+            "device":               device,
+        }
+        client.publish(topic, json.dumps(payload), qos=0, retain=True)
+        debug(cfg, f"discovery → {topic}")
+
+
+def publish_sample(client: mqtt.Client, cfg: Config, sample: dict):
+    """Flatten a single sample's groups into 18 watt readings and publish."""
+    t = sample.get("t")
+    watts = []
+    for group in sample.get("g", []):
+        for ch in group.get("c", []):
+            w_wh = ch.get("w") or 0
+            watts.append(abs(w_wh) * WH_PER_SEC_TO_W)
+    if len(watts) != NUM_CIRCUITS:
+        debug(cfg, f"expected {NUM_CIRCUITS} circuits, got {len(watts)}; skipping t={t}")
+        return 0
+    for i, w in enumerate(watts):
+        client.publish(
+            cfg.state_topic(i),
+            json.dumps({"circuit": i + 1, "power": w, "t": t}),
+            qos=0, retain=True,
+        )
+    return len(watts)
+
+
+# ── HTTP handler ──────────────────────────────────────────────────────────────
+
+class SamplesHandler(BaseHTTPRequestHandler):
+    samples_path: str = SAMPLES_FILE
+    mqtt_client: mqtt.Client = None    # set by main()
+    cfg: Config = None                 # set by main()
+
+    def do_POST(self):
+        m = SAMPLES_PATH_RE.match(self.path)
+        if not m:
+            self.send_error(404)
+            return
+
+        device = m.group(1)
+        length = int(self.headers.get("Content-Length", 0))
+        raw    = self.rfile.read(length) if length else b""
+
+        data = raw
+        if self.headers.get("Content-Encoding", "").lower() == "deflate":
+            try:
+                data = zlib.decompress(raw)
+            except zlib.error:
+                try:
+                    data = zlib.decompress(raw, -zlib.MAX_WBITS)
+                except zlib.error as e:
+                    print(f"[samples] deflate error from {device}: {e}")
+                    self.send_error(400, "bad deflate body")
+                    return
+
+        try:
+            payload = msgpack.unpackb(data, raw=False, strict_map_key=False)
+        except Exception as e:
+            print(f"[samples] msgpack error from {device}: {e}")
+            self.send_error(400, "bad msgpack body")
+            return
+
+        record = {
+            "timestamp":   datetime.datetime.now().isoformat(timespec="milliseconds"),
+            "device":      device,
+            "remote_addr": self.client_address[0],
+            "payload":     payload,
+        }
+        with open(self.samples_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        # Republish each sample to MQTT (most recent last → retained value is newest).
+        samples = payload.get("s", []) if isinstance(payload, dict) else []
+        samples = sorted(samples, key=lambda s: s.get("t", 0))
+        published = 0
+        for s in samples:
+            published += 1 if publish_sample(self.mqtt_client, self.cfg, s) else 0
+
+        print(f"[samples] {record['timestamp']}  {device}  {len(samples)} sample(s), "
+              f"{published} published → {self.samples_path}")
+
+        body = b'{"messages":0}'
+        self.send_response(200)
+        self.send_header("Content-Type",   "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):    self.send_error(404)
+    def do_PUT(self):    self.send_error(404)
+    def do_PATCH(self):  self.send_error(404)
+    def do_DELETE(self): self.send_error(404)
+    def do_HEAD(self):   self.send_error(404)
+    def do_OPTIONS(self): self.send_error(404)
+
+    def log_message(self, *_):
+        pass
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(description="EnergyCurb samples → MQTT bridge")
+    ap.add_argument("--config",  default="config.yaml", help="Config YAML path (default: config.yaml)")
+    ap.add_argument("--host",    default="0.0.0.0",     help="HTTP bind address (default: 0.0.0.0)")
+    ap.add_argument("--port",    default=80, type=int,  help="HTTP listen port  (default: 80)")
+    ap.add_argument("--samples", default=SAMPLES_FILE,  help=f"Samples JSONL path (default: {SAMPLES_FILE})")
+    args = ap.parse_args()
+
+    try:
+        cfg = Config(args.config)
+    except FileNotFoundError:
+        print(f"[fatal] config file not found: {args.config}", file=sys.stderr)
+        sys.exit(1)
+
+    client = connect_mqtt(cfg)
+
+    SamplesHandler.samples_path = args.samples
+    SamplesHandler.mqtt_client  = client
+    SamplesHandler.cfg          = cfg
+
+    server = HTTPServer((args.host, args.port), SamplesHandler)
+    print(f"[server] Listening on http://{args.host}:{args.port}/v3/samples/<device>")
+    print(f"[server] Samples log : {args.samples}")
+    print(f"[server] MQTT topic  : {cfg.topic}/circuit_1..{NUM_CIRCUITS}")
+    print(f"[server] Press Ctrl+C to stop.\n")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[server] Shutting down.")
+        server.server_close()
+        client.loop_stop()
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The Curb cloud service has been discontinued, so we cannot extract data from that service any more. The devices locally expose some log files on port 80 which include the 1-minute aggregate usage data. This pull request updates the script to pull the data from the local source now that the cloud service is gone.

One limitation is that the data on port 80 appears to update only once every 5 minutes. The last 5 readings are available (about 200 minutes worth of history is visible) so the data is published in bursts of 5, and there is a roughly 1 to 5 minute lag in the displayed readings. The data is published with the timestamp value of the data, so Home Assistant should be able to create a continuous plot of the data despite the burstiness.